### PR TITLE
feat: add purchase record and budget serverless functions

### DIFF
--- a/netlify/functions/get-budget-status.js
+++ b/netlify/functions/get-budget-status.js
@@ -1,0 +1,22 @@
+if (process.env.NODE_ENV !== 'production') {
+  try { require('dotenv').config(); } catch (e) {}
+}
+
+const controller = require('../../src/controllers/purchaseRecordController');
+
+function buildHandler(ctrl = controller) {
+  return async function(event) {
+    if (event.httpMethod !== 'GET') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    try {
+      const result = await ctrl.getBudgetStatus();
+      return { statusCode: 200, body: JSON.stringify(result) };
+    } catch (e) {
+      return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
+    }
+  };
+}
+
+exports.handler = buildHandler();
+exports.buildHandler = buildHandler;

--- a/netlify/functions/insert-purchase-record.js
+++ b/netlify/functions/insert-purchase-record.js
@@ -1,0 +1,23 @@
+if (process.env.NODE_ENV !== 'production') {
+  try { require('dotenv').config(); } catch (e) {}
+}
+
+const controller = require('../../src/controllers/purchaseRecordController');
+
+function buildHandler(ctrl = controller) {
+  return async function(event) {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    try {
+      const data = JSON.parse(event.body);
+      const result = await ctrl.insertPurchaseRecord(data);
+      return { statusCode: 200, body: JSON.stringify(result) };
+    } catch (e) {
+      return { statusCode: 400, body: JSON.stringify({ error: e.message }) };
+    }
+  };
+}
+
+exports.handler = buildHandler();
+exports.buildHandler = buildHandler;

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   },
   "devDependencies": {
     "netlify-cli": "^22.2.2"
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/src/controllers/purchaseRecordController.js
+++ b/src/controllers/purchaseRecordController.js
@@ -1,0 +1,11 @@
+const service = require('../services/purchaseRecordService');
+
+async function insertPurchaseRecord(data, srv = service) {
+  return srv.insertPurchaseRecord(data);
+}
+
+async function getBudgetStatus(srv = service) {
+  return srv.getBudgetStatus();
+}
+
+module.exports = { insertPurchaseRecord, getBudgetStatus };

--- a/src/repositories/purchaseRecordRepository.js
+++ b/src/repositories/purchaseRecordRepository.js
@@ -1,0 +1,41 @@
+const { createClient } = require('@supabase/supabase-js');
+
+function getClient() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_API_KEY || process.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Supabase credentials are required');
+  }
+  return createClient(supabaseUrl, supabaseKey);
+}
+
+async function insertPurchaseRecord(record) {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from('purchase_records')
+    .insert(record)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function fetchBudgets() {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from('budgets')
+    .select('category, limit');
+  if (error) throw new Error(error.message);
+  return data || [];
+}
+
+async function fetchTotalSpent() {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from('purchase_records')
+    .select('category, amount');
+  if (error) throw new Error(error.message);
+  return data || [];
+}
+
+module.exports = { insertPurchaseRecord, fetchBudgets, fetchTotalSpent };

--- a/src/services/purchaseRecordService.js
+++ b/src/services/purchaseRecordService.js
@@ -1,0 +1,40 @@
+const repository = require('../repositories/purchaseRecordRepository');
+
+function validateRecord(data) {
+  const required = ['user_id', 'amount', 'category'];
+  for (const field of required) {
+    if (data[field] === undefined || data[field] === null) {
+      throw new Error(`Missing field: ${field}`);
+    }
+  }
+}
+
+async function insertPurchaseRecord(data, repo = repository) {
+  validateRecord(data);
+  return repo.insertPurchaseRecord(data);
+}
+
+async function getBudgetStatus(repo = repository) {
+  const budgets = await repo.fetchBudgets();
+  const spent = await repo.fetchTotalSpent();
+  const totals = spent.reduce((acc, rec) => {
+    acc[rec.category] = (acc[rec.category] || 0) + rec.amount;
+    return acc;
+  }, {});
+  return budgets.map(budget => {
+    const spentAmount = totals[budget.category] || 0;
+    const percentage = budget.limit > 0 ? (spentAmount / budget.limit) * 100 : 0;
+    let alert = null;
+    if (percentage >= 100) alert = 'limit exceeded';
+    else if (percentage >= 80) alert = 'near limit';
+    return {
+      category: budget.category,
+      limit: budget.limit,
+      spent: spentAmount,
+      percentage,
+      alert
+    };
+  });
+}
+
+module.exports = { insertPurchaseRecord, getBudgetStatus };

--- a/tests/e2e/purchaseRecordFunctions.test.js
+++ b/tests/e2e/purchaseRecordFunctions.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildHandler: buildInsert } = require('../../netlify/functions/insert-purchase-record');
+const { buildHandler: buildGet } = require('../../netlify/functions/get-budget-status');
+const service = require('../../src/services/purchaseRecordService');
+
+test('insert-purchase-record handler returns 200', async () => {
+  const mockRepo = { insertPurchaseRecord: async (rec) => ({ id: 1, ...rec }) };
+  const mockController = {
+    insertPurchaseRecord: (data) => service.insertPurchaseRecord(data, mockRepo)
+  };
+  const handler = buildInsert(mockController);
+  const event = { httpMethod: 'POST', body: JSON.stringify({ user_id: 1, amount: 5, category: 'food' }) };
+  const res = await handler(event);
+  assert.equal(res.statusCode, 200);
+});
+
+test('get-budget-status handler returns data with percentages', async () => {
+  const mockRepo = {
+    fetchBudgets: async () => [{ category: 'food', limit: 100 }],
+    fetchTotalSpent: async () => [{ category: 'food', amount: 40 }]
+  };
+  const mockController = {
+    getBudgetStatus: () => service.getBudgetStatus(mockRepo)
+  };
+  const handler = buildGet(mockController);
+  const event = { httpMethod: 'GET' };
+  const res = await handler(event);
+  const body = JSON.parse(res.body);
+  assert.equal(body[0].percentage, 40);
+});

--- a/tests/integration/purchaseRecordController.test.js
+++ b/tests/integration/purchaseRecordController.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const controller = require('../../src/controllers/purchaseRecordController');
+const service = require('../../src/services/purchaseRecordService');
+
+test('controller integrates with service to insert record', async () => {
+  const mockRepo = {
+    insertPurchaseRecord: async (rec) => ({ id: 1, ...rec })
+  };
+  const mockService = {
+    insertPurchaseRecord: (data) => service.insertPurchaseRecord(data, mockRepo)
+  };
+  const result = await controller.insertPurchaseRecord({ user_id: 1, amount: 5, category: 'food' }, mockService);
+  assert.equal(result.id, 1);
+});
+
+test('controller integrates with service to get budget status', async () => {
+  const mockRepo = {
+    fetchBudgets: async () => [{ category: 'food', limit: 100 }],
+    fetchTotalSpent: async () => [{ category: 'food', amount: 50 }]
+  };
+  const mockService = {
+    getBudgetStatus: () => service.getBudgetStatus(mockRepo)
+  };
+  const result = await controller.getBudgetStatus(mockService);
+  assert.deepStrictEqual(result, [
+    { category: 'food', limit: 100, spent: 50, percentage: 50, alert: null }
+  ]);
+});

--- a/tests/unit/purchaseRecordService.test.js
+++ b/tests/unit/purchaseRecordService.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const service = require('../../src/services/purchaseRecordService');
+
+test('insertPurchaseRecord throws on missing fields', async () => {
+  await assert.rejects(
+    service.insertPurchaseRecord({ amount: 10, category: 'food' }, { insertPurchaseRecord: async () => ({}) }),
+    /Missing field: user_id/
+  );
+});
+
+test('getBudgetStatus calculates percentages and alerts', async () => {
+  const mockRepo = {
+    fetchBudgets: async () => [{ category: 'food', limit: 100 }],
+    fetchTotalSpent: async () => [{ category: 'food', amount: 90 }]
+  };
+  const result = await service.getBudgetStatus(mockRepo);
+  assert.deepStrictEqual(result, [
+    { category: 'food', limit: 100, spent: 90, percentage: 90, alert: 'near limit' }
+  ]);
+});


### PR DESCRIPTION
## Summary
- add serverless function to insert purchase records
- add serverless function to get budget status
- cover logic with unit, integration, and e2e tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895701e56d88325b80c865c73eb8f7f