### PR TITLE
feat: integrate OCR receipt processing

### DIFF
--- a/netlify/functions/process-receipt-ocr.js
+++ b/netlify/functions/process-receipt-ocr.js
@@ -1,0 +1,23 @@
+if (process.env.NODE_ENV !== 'production') {
+  try { require('dotenv').config(); } catch (e) {}
+}
+
+const controller = require('../../src/controllers/ocrController');
+
+function buildHandler(ctrl = controller) {
+  return async function(event) {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    try {
+      const data = JSON.parse(event.body);
+      const result = await ctrl.processReceipt(data);
+      return { statusCode: 200, body: JSON.stringify(result) };
+    } catch (e) {
+      return { statusCode: 400, body: JSON.stringify({ error: e.message }) };
+    }
+  };
+}
+
+exports.handler = buildHandler();
+exports.buildHandler = buildHandler;

--- a/src/controllers/ocrController.js
+++ b/src/controllers/ocrController.js
@@ -1,0 +1,7 @@
+const service = require('../services/ocrService');
+
+async function processReceipt(data, srv = service) {
+  return srv.processReceipt(data);
+}
+
+module.exports = { processReceipt };

--- a/src/services/ocrService.js
+++ b/src/services/ocrService.js
@@ -1,0 +1,48 @@
+const purchaseService = require('./purchaseRecordService');
+
+// Categorize items based on description or vendor keywords
+function categorizeItem(description = '', vendor = '') {
+  const str = `${description} ${vendor}`.toLowerCase();
+  if (/a[cç]ougue|carne/.test(str)) return 'butcher';
+  if (/hortifr[uú]ti|fruta|legume|verdura|banana|maç|maca|laranja/.test(str)) return 'produce';
+  return 'market';
+}
+
+// Parse OCR text lines into items with description and amount
+function parseLines(text) {
+  if (!text) throw new Error('No OCR text provided');
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => {
+      const match = line.match(/(.+?)\s+(\d+[\.,]?\d*)$/);
+      if (!match) throw new Error(`Invalid line: ${line}`);
+      const desc = match[1];
+      const amount = parseFloat(match[2].replace(',', '.'));
+      if (Number.isNaN(amount)) throw new Error(`Invalid amount in line: ${line}`);
+      return { desc, amount };
+    });
+}
+
+// Process OCR text, calculate totals per category and insert records
+async function processReceipt({ user_id, vendor = '', text }, srv = purchaseService) {
+  try {
+    const items = parseLines(text);
+    const totals = {};
+    for (const item of items) {
+      const category = categorizeItem(item.desc, vendor);
+      totals[category] = (totals[category] || 0) + item.amount;
+    }
+    const records = [];
+    for (const [category, amount] of Object.entries(totals)) {
+      const record = await srv.insertPurchaseRecord({ user_id, amount, category });
+      records.push(record);
+    }
+    return { manualEntry: false, records, totals };
+  } catch (e) {
+    return { manualEntry: true, error: e.message };
+  }
+}
+
+module.exports = { categorizeItem, processReceipt, parseLines };

--- a/tests/e2e/processReceiptOCRFunction.test.js
+++ b/tests/e2e/processReceiptOCRFunction.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { buildHandler } = require('../../netlify/functions/process-receipt-ocr');
+const service = require('../../src/services/ocrService');
+
+const mockPurchaseService = {
+  insertPurchaseRecord: async (rec) => ({ id: 1, ...rec })
+};
+
+test('process-receipt-ocr handler returns records', async () => {
+  const mockController = {
+    processReceipt: (data) => service.processReceipt(data, mockPurchaseService)
+  };
+  const handler = buildHandler(mockController);
+  const event = { httpMethod: 'POST', body: JSON.stringify({ user_id: 1, vendor: 'Mercado', text: 'Banana 5\nCarne 10' }) };
+  const res = await handler(event);
+  const body = JSON.parse(res.body);
+  assert.equal(res.statusCode, 200);
+  assert.equal(body.records.length, 2);
+});

--- a/tests/integration/ocrController.test.js
+++ b/tests/integration/ocrController.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const controller = require('../../src/controllers/ocrController');
+const service = require('../../src/services/ocrService');
+
+const mockPurchaseService = {
+  insertPurchaseRecord: async (rec) => ({ id: 1, ...rec })
+};
+
+test('controller processes receipt via service', async () => {
+  const mockService = {
+    processReceipt: (data) => service.processReceipt(data, mockPurchaseService)
+  };
+  const result = await controller.processReceipt({ user_id: 1, vendor: 'Mercado', text: 'Banana 5' }, mockService);
+  assert.equal(result.records[0].category, 'produce');
+});

--- a/tests/unit/ocrService.test.js
+++ b/tests/unit/ocrService.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const service = require('../../src/services/ocrService');
+
+const mockPurchaseService = {
+  insertPurchaseRecord: async (rec) => ({ id: Math.random(), ...rec })
+};
+
+test('processReceipt categorizes items and inserts records', async () => {
+  const text = 'Banana 5\nCarne 10';
+  const result = await service.processReceipt({ user_id: 1, vendor: 'Mercado Central', text }, mockPurchaseService);
+  assert.equal(result.manualEntry, false);
+  assert.equal(result.records.length, 2);
+  const categories = result.records.map(r => r.category).sort();
+  assert.deepStrictEqual(categories, ['butcher', 'produce']);
+});
+
+test('processReceipt falls back to manual on parse error', async () => {
+  const result = await service.processReceipt({ user_id: 1, vendor: '', text: 'invalid line' }, mockPurchaseService);
+  assert.equal(result.manualEntry, true);
+});


### PR DESCRIPTION
## Summary
- add OCR service to categorize items and insert purchase records
- expose controller and Netlify function for OCR-based receipt processing
- cover OCR flow with unit, integration, and e2e tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895770688808325b166c9b3b8fda52a