### PR TITLE
feat: add budgeting and purchase dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
             <button class="nav-tab active" onclick="showTab('mercados')">Mercados</button>
             <button class="nav-tab" onclick="showTab('produtos')">Produtos</button>
             <button class="nav-tab" onclick="showTab('barganha')">🔥 Barganha</button>
+            <button class="nav-tab" onclick="showTab('metas')">Metas</button>
+            <button class="nav-tab" onclick="showTab('compra')">Registrar Compra</button>
+            <button class="nav-tab" onclick="showTab('dashboard')">Dashboard</button>
         </div>
 
         <!-- Tab Mercados -->
@@ -142,6 +145,34 @@
                 </div>
             </div>
         </div>
+
+        <!-- Tab Metas -->
+        <div id="metas" class="tab-content">
+            <h2>Metas e Orçamento</h2>
+            <form id="budgetForm">
+                <input type="text" id="budgetCategory" placeholder="Categoria" required>
+                <input type="number" id="budgetLimit" placeholder="Limite" required>
+                <button type="submit" class="btn">Salvar</button>
+            </form>
+            <div id="budgetsList" class="items-grid"></div>
+        </div>
+
+        <!-- Tab Registrar Compra -->
+        <div id="compra" class="tab-content">
+            <h2>Registrar Compra</h2>
+            <form id="purchaseForm">
+                <input type="number" id="purchaseAmount" placeholder="Valor" step="0.01" required>
+                <input type="text" id="purchaseCategory" placeholder="Categoria" required>
+                <input type="date" id="purchaseDate" required>
+                <button type="submit" class="btn">Registrar</button>
+            </form>
+        </div>
+
+        <!-- Tab Dashboard -->
+        <div id="dashboard" class="tab-content">
+            <h2>Dashboard</h2>
+            <div id="dashboardList" class="items-grid"></div>
+        </div>
     </div>
 
     <!-- index.html -->
@@ -152,6 +183,9 @@
     <script src="/static/js/barcode-scanner.js"></script>
     <script src="/static/js/bargainly-app.js"></script>
     <script src="/static/js/tabs-app.js"></script>
-    
+    <script src="/static/js/budgets-app.js"></script>
+    <script src="/static/js/purchase-app.js"></script>
+    <script src="/static/js/dashboard-app.js"></script>
+
 </body>
 </html>

--- a/netlify/functions/set-budget.js
+++ b/netlify/functions/set-budget.js
@@ -1,0 +1,23 @@
+if (process.env.NODE_ENV !== 'production') {
+  try { require('dotenv').config(); } catch (e) {}
+}
+
+const controller = require('../../src/controllers/purchaseRecordController');
+
+function buildHandler(ctrl = controller) {
+  return async function(event) {
+    if (event.httpMethod !== 'POST') {
+      return { statusCode: 405, body: 'Method Not Allowed' };
+    }
+    try {
+      const data = JSON.parse(event.body);
+      const result = await ctrl.setBudget(data);
+      return { statusCode: 200, body: JSON.stringify(result) };
+    } catch (e) {
+      return { statusCode: 400, body: JSON.stringify({ error: e.message }) };
+    }
+  };
+}
+
+exports.handler = buildHandler();
+exports.buildHandler = buildHandler;

--- a/src/controllers/purchaseRecordController.js
+++ b/src/controllers/purchaseRecordController.js
@@ -8,4 +8,8 @@ async function getBudgetStatus(srv = service) {
   return srv.getBudgetStatus();
 }
 
-module.exports = { insertPurchaseRecord, getBudgetStatus };
+async function setBudget(data, srv = service) {
+  return srv.setBudget(data);
+}
+
+module.exports = { insertPurchaseRecord, getBudgetStatus, setBudget };

--- a/src/repositories/purchaseRecordRepository.js
+++ b/src/repositories/purchaseRecordRepository.js
@@ -29,6 +29,17 @@ async function fetchBudgets() {
   return data || [];
 }
 
+async function upsertBudget(budget) {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from('budgets')
+    .upsert(budget)
+    .select()
+    .single();
+  if (error) throw new Error(error.message);
+  return data;
+}
+
 async function fetchTotalSpent() {
   const supabase = getClient();
   const { data, error } = await supabase
@@ -38,4 +49,4 @@ async function fetchTotalSpent() {
   return data || [];
 }
 
-module.exports = { insertPurchaseRecord, fetchBudgets, fetchTotalSpent };
+module.exports = { insertPurchaseRecord, fetchBudgets, fetchTotalSpent, upsertBudget };

--- a/src/services/purchaseRecordService.js
+++ b/src/services/purchaseRecordService.js
@@ -9,9 +9,23 @@ function validateRecord(data) {
   }
 }
 
+function validateBudget(data) {
+  const required = ['category', 'limit'];
+  for (const field of required) {
+    if (data[field] === undefined || data[field] === null) {
+      throw new Error(`Missing field: ${field}`);
+    }
+  }
+}
+
 async function insertPurchaseRecord(data, repo = repository) {
   validateRecord(data);
   return repo.insertPurchaseRecord(data);
+}
+
+async function setBudget(data, repo = repository) {
+  validateBudget(data);
+  return repo.upsertBudget(data);
 }
 
 async function getBudgetStatus(repo = repository) {
@@ -37,4 +51,4 @@ async function getBudgetStatus(repo = repository) {
   });
 }
 
-module.exports = { insertPurchaseRecord, getBudgetStatus };
+module.exports = { insertPurchaseRecord, getBudgetStatus, setBudget };

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -493,3 +493,17 @@ body {
   object-fit: cover;
   z-index: 1;
 }
+
+.budget-bar-container {
+  width: 100%;
+  background: #e2e8f0;
+  height: 10px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.budget-bar {
+  height: 10px;
+  background: #48bb78;
+  border-radius: 4px;
+}

--- a/static/js/budgets-app.js
+++ b/static/js/budgets-app.js
@@ -1,0 +1,45 @@
+async function loadBudgets() {
+  try {
+    const res = await fetch('/.netlify/functions/get-budget-status');
+    const budgets = await res.json();
+    const list = document.getElementById('budgetsList');
+    list.innerHTML = '';
+    if (budgets.length === 0) {
+      list.innerHTML = '<p>Nenhuma meta cadastrada</p>';
+      return;
+    }
+    budgets.forEach(b => {
+      const item = document.createElement('div');
+      item.className = 'budget-item';
+      const bar = document.createElement('div');
+      bar.className = 'budget-bar';
+      bar.style.width = Math.min(b.percentage, 100) + '%';
+      if (b.alert === 'near limit') bar.style.background = '#ecc94b';
+      if (b.alert === 'limit exceeded') bar.style.background = '#e53e3e';
+      item.innerHTML = `<strong>${b.category}</strong>: R$${b.spent} / R$${b.limit}`;
+      const container = document.createElement('div');
+      container.className = 'budget-bar-container';
+      container.appendChild(bar);
+      item.appendChild(container);
+      list.appendChild(item);
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+async function submitBudgetForm(e) {
+  e.preventDefault();
+  const category = document.getElementById('budgetCategory').value;
+  const limit = Number(document.getElementById('budgetLimit').value);
+  await fetch('/.netlify/functions/set-budget', {
+    method: 'POST',
+    body: JSON.stringify({ category, limit })
+  });
+  e.target.reset();
+  loadBudgets();
+}
+
+document.getElementById('budgetForm')?.addEventListener('submit', submitBudgetForm);
+
+document.addEventListener('DOMContentLoaded', loadBudgets);

--- a/static/js/dashboard-app.js
+++ b/static/js/dashboard-app.js
@@ -1,0 +1,22 @@
+async function loadDashboard() {
+  try {
+    const res = await fetch('/.netlify/functions/get-budget-status');
+    const budgets = await res.json();
+    const list = document.getElementById('dashboardList');
+    list.innerHTML = '';
+    budgets.forEach(b => {
+      const item = document.createElement('div');
+      item.className = 'dashboard-item';
+      let color = '#48bb78';
+      if (b.alert === 'near limit') color = '#ecc94b';
+      if (b.alert === 'limit exceeded') color = '#e53e3e';
+      item.innerHTML = `<strong>${b.category}</strong>: R$${b.spent} / R$${b.limit}`;
+      item.style.color = color;
+      list.appendChild(item);
+    });
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadDashboard);

--- a/static/js/purchase-app.js
+++ b/static/js/purchase-app.js
@@ -1,0 +1,15 @@
+async function submitPurchaseForm(e) {
+  e.preventDefault();
+  const user_id = 1; // demo user
+  const amount = Number(document.getElementById('purchaseAmount').value);
+  const category = document.getElementById('purchaseCategory').value;
+  const date = document.getElementById('purchaseDate').value;
+  await fetch('/.netlify/functions/insert-purchase-record', {
+    method: 'POST',
+    body: JSON.stringify({ user_id, amount, category, date })
+  });
+  e.target.reset();
+  alert('Compra registrada');
+}
+
+document.getElementById('purchaseForm')?.addEventListener('submit', submitPurchaseForm);

--- a/tests/e2e/purchaseRecordFunctions.test.js
+++ b/tests/e2e/purchaseRecordFunctions.test.js
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert');
 const { buildHandler: buildInsert } = require('../../netlify/functions/insert-purchase-record');
 const { buildHandler: buildGet } = require('../../netlify/functions/get-budget-status');
+const { buildHandler: buildSet } = require('../../netlify/functions/set-budget');
 const service = require('../../src/services/purchaseRecordService');
 
 test('insert-purchase-record handler returns 200', async () => {
@@ -28,4 +29,15 @@ test('get-budget-status handler returns data with percentages', async () => {
   const res = await handler(event);
   const body = JSON.parse(res.body);
   assert.equal(body[0].percentage, 40);
+});
+
+test('set-budget handler returns 200', async () => {
+  const mockRepo = { upsertBudget: async (data) => ({ id: 1, ...data }) };
+  const mockController = {
+    setBudget: (data) => service.setBudget(data, mockRepo)
+  };
+  const handler = buildSet(mockController);
+  const event = { httpMethod: 'POST', body: JSON.stringify({ category: 'food', limit: 100 }) };
+  const res = await handler(event);
+  assert.equal(res.statusCode, 200);
 });

--- a/tests/integration/purchaseRecordController.test.js
+++ b/tests/integration/purchaseRecordController.test.js
@@ -27,3 +27,12 @@ test('controller integrates with service to get budget status', async () => {
     { category: 'food', limit: 100, spent: 50, percentage: 50, alert: null }
   ]);
 });
+
+test('controller integrates with service to set budget', async () => {
+  const mockRepo = { upsertBudget: async (data) => ({ id: 1, ...data }) };
+  const mockService = {
+    setBudget: (data) => service.setBudget(data, mockRepo)
+  };
+  const result = await controller.setBudget({ category: 'travel', limit: 300 }, mockService);
+  assert.equal(result.id, 1);
+});

--- a/tests/unit/purchaseRecordService.test.js
+++ b/tests/unit/purchaseRecordService.test.js
@@ -19,3 +19,16 @@ test('getBudgetStatus calculates percentages and alerts', async () => {
     { category: 'food', limit: 100, spent: 90, percentage: 90, alert: 'near limit' }
   ]);
 });
+
+test('setBudget validates required fields', async () => {
+  await assert.rejects(
+    service.setBudget({ limit: 100 }, { upsertBudget: async () => ({}) }),
+    /Missing field: category/
+  );
+});
+
+test('setBudget delegates to repository', async () => {
+  const mockRepo = { upsertBudget: async (data) => ({ id: 1, ...data }) };
+  const result = await service.setBudget({ category: 'food', limit: 200 }, mockRepo);
+  assert.equal(result.id, 1);
+});


### PR DESCRIPTION
## Summary
- add budget upsert repository and service with validation
- expose budget set endpoint and netlify function
- create UI tabs for budgeting, purchase entry and dashboard with progress bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957a68bee48325bc7e3d21dff7515a