### PR TITLE
Add email/password login and cookie-based auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,16 +176,20 @@
     </div>
 
     <!-- index.html -->
-    <script src="https://unpkg.com/@ericblade/quagga2/dist/quagga.min.js"></script>
-    <script src="/static/js/utils.js"></script>
-    <script src="/static/js/products-app.js"></script>
-    <script src="/static/js/markets-app.js"></script>
-    <script src="/static/js/barcode-scanner.js"></script>
-    <script src="/static/js/bargainly-app.js"></script>
-    <script src="/static/js/tabs-app.js"></script>
-    <script src="/static/js/budgets-app.js"></script>
-    <script src="/static/js/purchase-app.js"></script>
-    <script src="/static/js/dashboard-app.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+      <script>window.SUPABASE_URL="__SUPABASE_URL__";window.SUPABASE_ANON_KEY="__SUPABASE_ANON_KEY__";</script>
+      <script src="/static/js/supabase-client.js"></script>
+      <script src="/static/js/auth.js"></script>
+      <script src="https://unpkg.com/@ericblade/quagga2/dist/quagga.min.js"></script>
+      <script src="/static/js/utils.js"></script>
+      <script src="/static/js/products-app.js"></script>
+      <script src="/static/js/markets-app.js"></script>
+      <script src="/static/js/barcode-scanner.js"></script>
+      <script src="/static/js/bargainly-app.js"></script>
+      <script src="/static/js/tabs-app.js"></script>
+      <script src="/static/js/budgets-app.js"></script>
+      <script src="/static/js/purchase-app.js"></script>
+      <script src="/static/js/dashboard-app.js"></script>
 
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Login - Barganha App</title>
+  <link rel="stylesheet" href="/static/css/style.css" />
+  <style>
+    .login-form {
+      max-width: 400px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 15px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Barganha App</h1>
+      <p>Faça login para continuar</p>
+    </div>
+    <form id="loginForm" class="login-form">
+      <div class="input-group">
+        <label for="email">Email</label>
+        <input type="email" id="email" required />
+      </div>
+      <div class="input-group">
+        <label for="password">Senha</label>
+        <input type="password" id="password" required />
+      </div>
+      <button type="submit" class="btn">Entrar</button>
+      <div id="loginError" class="error-message"></div>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script>window.SUPABASE_URL="__SUPABASE_URL__";window.SUPABASE_ANON_KEY="__SUPABASE_ANON_KEY__";</script>
+  <script src="/static/js/supabase-client.js"></script>
+  <script src="/static/js/auth.js"></script>
+  <script src="/static/js/login-app.js"></script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
 [build]
   publish = "."
-  command = "sed -i \"s/__GEMINI_API_KEY__/$GEMINI_API_KEY/g\" poc/poc-upload-captura-foto-ocr-gemini.html && echo 'Deploy estático'" 
+  command = '''
+  sed -i "s/__GEMINI_API_KEY__/$GEMINI_API_KEY/g" poc/poc-upload-captura-foto-ocr-gemini.html &&
+  sed -i "s|__SUPABASE_URL__|$SUPABASE_URL|g" index.html &&
+  sed -i "s|__SUPABASE_ANON_KEY__|$SUPABASE_ANON_KEY|g" index.html &&
+  echo 'Deploy estático'
+  '''

--- a/netlify/functions/create-products.js
+++ b/netlify/functions/create-products.js
@@ -12,6 +12,7 @@ exports.handler = async function(event) {
 
   try {
     const {
+      user_id,
       mercadoId,
       nome,
       unidade,
@@ -22,9 +23,14 @@ exports.handler = async function(event) {
       barcode
     } = JSON.parse(event.body);
 
+    if (!user_id) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Missing user_id' }) };
+    }
+
     const url = `${process.env.SUPABASE_URL}/rest/v1/products`;
     const body = JSON.stringify([
       {
+        user_id,
         market_id: mercadoId,
         name: nome,
         unit: unidade,
@@ -55,6 +61,7 @@ exports.handler = async function(event) {
     const data = await response.json();
     return { statusCode: 200, body: JSON.stringify(data[0]) };
   } catch (e) {
+    console.error('Erro ao inserir produto:', e);
     return { statusCode: 500, body: JSON.stringify({ error: e.message }) };
   }
 };

--- a/netlify/functions/get-products.js
+++ b/netlify/functions/get-products.js
@@ -12,7 +12,11 @@ exports.handler = async function(event) {
     }
 
     try {
-        const url = `${process.env.SUPABASE_URL}/rest/v1/products`;
+        const user_id = event.queryStringParameters?.user_id;
+        let url = `${process.env.SUPABASE_URL}/rest/v1/products`;
+        if (user_id) {
+            url += `?user_id=eq.${user_id}`;
+        }
 
         const response = await fetch(url, {
             method: 'GET',
@@ -26,15 +30,17 @@ exports.handler = async function(event) {
 
         if (!response.ok) {
             const text = await response.text();
+            console.error('Erro do Supabase:', text);
             throw new Error(text);
         }
 
         const data = await response.json();
         return { statusCode: 200, body: JSON.stringify(data) };
     }catch(error){
-        return { 
-            statusCode: 500, 
-            body: JSON.stringify({ error: 'Erro ao buscar produtos' }) 
+        console.error('Erro ao buscar produtos:', error);
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: 'Erro ao buscar produtos' })
         };
     }
 };

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,0 +1,34 @@
+function setUserCookie(userId) {
+  const expires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toUTCString();
+  document.cookie = `user_id=${userId}; expires=${expires}; path=/`;
+}
+
+function getUserIdFromCookie() {
+  const match = document.cookie.match(/(?:^|; )user_id=([^;]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+async function getUserId() {
+  const cookieId = getUserIdFromCookie();
+  if (cookieId) return cookieId;
+  if (!window.supabase?.auth) {
+    console.error('Supabase client not initialized');
+    return null;
+  }
+  const { data, error } = await supabase.auth.getUser();
+  if (error || !data.user) {
+    console.error('Erro ao obter usuário:', error);
+    return null;
+  }
+  setUserCookie(data.user.id);
+  return data.user.id;
+}
+
+function ensureAuth() {
+  if (window.location.pathname.endsWith('/login.html')) return;
+  if (!getUserIdFromCookie()) {
+    window.location.href = '/login.html';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', ensureAuth);

--- a/static/js/budgets-app.js
+++ b/static/js/budgets-app.js
@@ -1,6 +1,7 @@
 async function loadBudgets() {
   try {
-    const res = await fetch('/.netlify/functions/get-budget-status');
+    const user_id = await getUserId();
+    const res = await fetch(`/.netlify/functions/get-budget-status?user_id=${user_id}`);
     if (!res.ok) throw new Error('Falha ao carregar metas');
     const budgets = await res.json();
     const list = document.getElementById('budgetsList');
@@ -31,12 +32,21 @@ async function loadBudgets() {
 
 async function submitBudgetForm(e) {
   e.preventDefault();
-  const category = document.getElementById('budgetCategory').value;
-  const limit = Number(document.getElementById('budgetLimit').value);
-  await fetch('/.netlify/functions/set-budget', {
-    method: 'POST',
-    body: JSON.stringify({ category, limit })
-  });
+  try {
+    const user_id = await getUserId();
+    const category = document.getElementById('budgetCategory').value;
+    const limit = Number(document.getElementById('budgetLimit').value);
+    const res = await fetch('/.netlify/functions/set-budget', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id, category, limit })
+    });
+    if (!res.ok) {
+      console.error('Erro ao salvar meta:', await res.text());
+    }
+  } catch (err) {
+    console.error(err);
+  }
   e.target.reset();
   loadBudgets();
 }

--- a/static/js/dashboard-app.js
+++ b/static/js/dashboard-app.js
@@ -1,6 +1,7 @@
 async function loadDashboard() {
   try {
-    const res = await fetch('/.netlify/functions/get-budget-status');
+    const user_id = await getUserId();
+    const res = await fetch(`/.netlify/functions/get-budget-status?user_id=${user_id}`);
     if (!res.ok) throw new Error('Falha ao carregar metas');
     const budgets = await res.json();
     if (!Array.isArray(budgets)) throw new Error('Resposta inválida');

--- a/static/js/login-app.js
+++ b/static/js/login-app.js
@@ -1,0 +1,20 @@
+async function handleLogin(event) {
+  event.preventDefault();
+  const email = document.getElementById('email').value;
+  const password = document.getElementById('password').value;
+  if (!window.supabase?.auth) {
+    console.error('Supabase client not initialized');
+    return;
+  }
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    console.error('Erro de login:', error.message);
+    const errEl = document.getElementById('loginError');
+    if (errEl) errEl.textContent = 'Falha no login';
+    return;
+  }
+  setUserCookie(data.user.id);
+  window.location.href = '/';
+}
+
+document.getElementById('loginForm')?.addEventListener('submit', handleLogin);

--- a/static/js/supabase-client.js
+++ b/static/js/supabase-client.js
@@ -1,0 +1,36 @@
+// Initialize Supabase client for both browser and Netlify/Node environments
+(function (global) {
+  let url = global.SUPABASE_URL;
+  let anonKey = global.SUPABASE_ANON_KEY;
+
+  if ((!url || !anonKey) && typeof process !== 'undefined' && process.env) {
+    if (process.env.NODE_ENV !== 'production') {
+      try { require('dotenv').config(); } catch (e) {}
+    }
+    url = url || process.env.SUPABASE_URL;
+    anonKey = anonKey || process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_API_KEY;
+  }
+
+  if (!url || !anonKey) {
+    console.error('Supabase credentials are missing.');
+    return;
+  }
+
+  let createClient = global.supabase?.createClient;
+  if (!createClient && typeof require === 'function') {
+    try { ({ createClient } = require('@supabase/supabase-js')); } catch (e) {}
+  }
+
+  if (!createClient) {
+    console.error('Supabase library not loaded.');
+    return;
+  }
+
+  const client = createClient(url, anonKey);
+
+  if (global.window) {
+    global.supabase = client;
+  } else {
+    module.exports = client;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
- Build responsive login page that signs in with Supabase email/password and saves the user ID in a cookie
- Centralize authentication helpers to read the cookie and redirect unauthenticated users to the login page
- Use shared user ID across budget, dashboard and product flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896b70026008325afa39149a65ac0cd